### PR TITLE
Adding readme and pom fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Debouncer
+
+**Debouncer** is a small library intended for debouncing rapid events. 
+
+A debouncer is made up of three parts.
+
+- [_Accumulation_](#accumulators) - Accumulate events into some type of result.
+- [_Regulation_](#regulators) - Regulate the throughput of events.
+- [_Consumption_](#consumers) - Consumption of the events.
+
+### <a name="accumulators"/> Accumulators
+Accumulators accumulate value types into a result type. 
+
+|Accumulator | Description | Value Type | Result Type | Example Reason|
+|----------- | ----------- | ---------- | ----------- | --------------|
+|<a name="LatestValueAccumulator"/>`LatestValueAccumulator` | Only keeps the last value accumulated. | `T` | `T` | User is typing, but only need the final value entered.|
+|<a name="ListAccumulator"/>`ListAccumulator` | Keeps a list of value types accumulated | `T` | `List<T>` | Rapid events from an external source. All events need to be shown, but multiple updates would cause flickering.|
+|<a name="MapAccumulator"/>`MapAccumulator` | Keeps a map of value types to sub-accumulators. | `V` | `Map<K, Accumulator<V, R>>`| Rapid events coming in from an external source. Each event has a key that it can be grouped by. The resulting groupings can then be accumulated by one of the other accumulators. (See [Drainers.drainMap](#drainMap))|
+
+An Accumulator decorator is also included, with the following implementation:
+
+|Decorator | Usage|
+|--------- | -----|
+|<a name="SynchronizedAccumulator"/>`SynchronizedAccumulator` | Used to wrap an accumulator's calls in `synchronized` blocks.|
+
+### <a name="regulators"/> Regulators
+* Work in progress
+
+### <a name="consumers"/> Consumers/Drainers
+Consumers use the `java.util.function.Consumer` class. Several convenience methods are included in the `Drainers` utility class.
+
+|`Drainers` Method | Arguments | Purpose|
+|----------------- | --------- | -------|
+|<a name="noopDrainer"/>`noopDrainer`     | *none*    | Does nothing during drain. Used primarily for testing accumulators. Can be used to clear an accumulator. |
+|<a name="drainIterable"/>`drainIterable`   | `Consumer<T>` | Used to drain an accumulator whose result type extends `Iterable`. Drains each value into the provided consumer.|
+|<a name="drainMap"/>`drainMap`        | `BiConsumer<K, R>` | Used to drain a `MapAccumulator` by key and result type. Drains each key and the result of each associated sub-accumulator into the provided bi-function.|`Consumer<K, R>` | Used to drain a `MapAccumulator` by key and result type. Drains each key and the result of each associated sub-accumulator into the provided bi-function.|

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.proeuclid</groupId>
+    <groupId>com.frynd</groupId>
     <artifactId>debouncer</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
         <junit.version>4.12</junit.version>
         <junit.jupiter.version>5.0.3</junit.jupiter.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
@@ -18,6 +19,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/main/java/com/frynd/debouncer/accumulator/Accumulator.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/Accumulator.java
@@ -6,7 +6,7 @@ import java.util.function.Consumer;
  * Accumulator interface.
  * Accumulates values that may later be consumed.
  *
- * @param <V> value types to be accumulated.
+ * @param <V> value types to be accumulated
  * @param <R> result type to be consumed
  */
 public interface Accumulator<V, R> {

--- a/src/main/java/com/frynd/debouncer/accumulator/Drainers.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/Drainers.java
@@ -42,7 +42,7 @@ public class Drainers {
      * @return a consumer that iterates over an iterable and applies {@code action} to each item
      * @throws NullPointerException if {@code action} is null
      */
-    public static <R, I extends Iterable<R>> Consumer<I> drainForEach(Consumer<? super R> action) {
+    public static <R, I extends Iterable<R>> Consumer<I> drainIterable(Consumer<? super R> action) {
         Objects.requireNonNull(action);
         return col -> col.forEach(action);
     }

--- a/src/main/java/com/frynd/debouncer/accumulator/impl/ListAccumulator.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/impl/ListAccumulator.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
  * <strong>Note:</strong> This implementation is not synchronized.
  *
  * @param <T> The type of item accumulated.
- * @see Drainers#drainForEach(Consumer)
+ * @see Drainers#drainIterable(Consumer)
  */
 public class ListAccumulator<T> implements Accumulator<T, List<T>> {
     private final ArrayList<T> list = new ArrayList<>();
@@ -43,7 +43,7 @@ public class ListAccumulator<T> implements Accumulator<T, List<T>> {
      *
      * @param consumer the consumer to pass the currently accumulated values to
      * @throws NullPointerException if {@code consumer} is null
-     * @see Drainers#drainForEach(Consumer)
+     * @see Drainers#drainIterable(Consumer)
      */
     @Override
     public void drain(Consumer<? super List<T>> consumer) {

--- a/src/test/java/com/frynd/debouncer/accumulator/DrainersTest.java
+++ b/src/test/java/com/frynd/debouncer/accumulator/DrainersTest.java
@@ -31,10 +31,10 @@ class DrainersTest {
     }
 
     @Test
-    @DisplayName("forEach drainer should drain each item.")
-    void forEach() {
+    @DisplayName("Iterable drainer should drain each item.")
+    void drainIterable() {
         AtomicInteger count = new AtomicInteger(0);
-        Consumer<Collection<String>> drainer = Drainers.drainForEach(str -> count.incrementAndGet());
+        Consumer<Collection<String>> drainer = Drainers.drainIterable(str -> count.incrementAndGet());
         List<String> strings = Arrays.asList("a", "b", "c", "d");
 
         drainer.accept(strings);
@@ -46,9 +46,9 @@ class DrainersTest {
         Assertions.assertEquals(strings.size(), count.get(), "count should be incremented for each value.");
 
         Assertions.assertThrows(NullPointerException.class, () -> {
-            Consumer<Iterable<Object>> shouldNotBeMade = Drainers.drainForEach(null);
+            Consumer<Iterable<Object>> shouldNotBeMade = Drainers.drainIterable(null);
             Assertions.fail("Drainer should not be made with null, but did: " + shouldNotBeMade);
-        }, "Should not be able to create a null forEach.");
+        }, "Should not be able to create a null Iterable drainer.");
     }
 
     @Test

--- a/src/test/java/com/frynd/debouncer/accumulator/impl/ListAccumulatorTest.java
+++ b/src/test/java/com/frynd/debouncer/accumulator/impl/ListAccumulatorTest.java
@@ -56,13 +56,13 @@ class ListAccumulatorTest {
     }
 
     @Test
-    @DisplayName("Test compatibility with Drainers.drainForEach.")
-    void drainForEach() {
+    @DisplayName("Test compatibility with Drainers.drainIterable.")
+    void drainIterable() {
         List<String> strings = Arrays.asList("abounding", "refuse", "plough");
         List<String> stringsCopy = new ArrayList<>(strings);
 
         strings.forEach(fixture::accumulate);
-        fixture.drain(Drainers.drainForEach(stringsCopy::remove));
+        fixture.drain(Drainers.drainIterable(stringsCopy::remove));
         Assertions.assertEquals(Collections.emptyList(), stringsCopy, "Each item should have been removed from stringsCopy");
     }
 }


### PR DESCRIPTION
Added README.md file to root.

pom.xml:
- Fixed maven-compiler-plugin version
- Fixed sourceEncoding
- Fixed groupId

Fixed some comments.

Renamed drainForEach to drainIterable to match drainMap

README anchors

- Added anchors to the various types for later reference.
- Added link from MapAccumulator to drainMap
- Hopefully fixed decorator table formatting