### PR TITLE
Adding the Debouncer

### DIFF
--- a/src/main/java/com/frynd/debouncer/Debouncer.java
+++ b/src/main/java/com/frynd/debouncer/Debouncer.java
@@ -1,0 +1,175 @@
+package com.frynd.debouncer;
+
+import com.frynd.debouncer.accumulator.Accumulator;
+import com.frynd.debouncer.accumulator.decorator.AccumulatingOn;
+import com.frynd.debouncer.accumulator.decorator.DrainingOn;
+import com.frynd.debouncer.regulator.Regulator;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Debouncing class.
+ * Accumulates events into an {@code Accumulator}, then drains to a {@code Consumer} with the flow between
+ * the two regulated by a {@code Regulator}.
+ * Usage:<pre>{@code
+ * Debouncer debouncer = Debouncer.accumulating(accumulator)
+ *                                .regulating(regulator)
+ *                                .draining(drainer);
+ * debouncer.accumulate(item);
+ * }</pre>
+ *
+ * @param <V> the value types to be accumulated.
+ * @see Accumulator
+ * @see Regulator
+ * @see Consumer
+ * @see com.frynd.debouncer.drainer.Drainers
+ */
+public class Debouncer<V> {
+    private final Accumulator<V, ?> accumulator;
+    private final Regulator regulator;
+
+    private <R> Debouncer(Accumulator<V, R> accumulator, Regulator regulator) {
+        this.accumulator = accumulator;
+        this.regulator = regulator;
+    }
+
+    /**
+     * Accumulates another event into the debouncer, and requests action from the regulator.
+     *
+     * @param value value to be accumulated
+     */
+    public void accumulate(V value) {
+        accumulator.accumulate(value);
+        regulator.requestAction();
+    }
+
+    /**
+     * Start debouncer builder with an accumulator.
+     *
+     * @param accumulator the accumulator the debouncer will use to accumulate events
+     * @param <V>         the value type to be accumulated
+     * @param <R>         the result type to be consumed later
+     * @return The first phase of the builder, which allows configuration of the accumulator and setting the
+     * regulator factory
+     * @see Accumulator
+     * @see DebouncerBuilder#regulating(Function)
+     */
+    public static <V, R> DebouncerBuilder<V, R> accumulating(Accumulator<V, R> accumulator) {
+        Objects.requireNonNull(accumulator);
+        return new DebouncerBuilder<>(accumulator);
+
+    }
+
+    /**
+     * Phased builder for Debouncer.
+     * Allows:
+     * - accumulatingOn - decorate current accumulator with executor based accumulation
+     * - drainingOn - decorate current accumulator with executor based draining
+     * - regulating - set regulator and move to next phase.
+     *
+     * @param <V> the value type to be accumulated
+     * @param <R> the result type to be consumed later
+     */
+    public static class DebouncerBuilder<V, R> {
+        private final Accumulator<V, R> accumulator;
+
+        private DebouncerBuilder(Accumulator<V, R> accumulator) {
+            this.accumulator = accumulator;
+        }
+
+        /**
+         * Returns a debouncer builder whose result debouncer will accumulate values on
+         * a separate {@code executor}.
+         * Useful if the accumulation calculation is involved, and slowing down callers
+         * off accumulate is undesirable.
+         *
+         * @param executor the executor to run accumulation on
+         * @return a new builder that uses executor based accumulation
+         * @see AccumulatingOn
+         * @see java.util.concurrent.Executors
+         */
+        public DebouncerBuilder<V, R> accumulatingOn(Executor executor) {
+            Objects.requireNonNull(executor);
+            return new DebouncerBuilder<>(new AccumulatingOn<>(accumulator, executor));
+        }
+
+        /**
+         * Returns a debouncer builder whose result debouncer will drain values on
+         * a separate {@code executor}.
+         * Useful if the draining method should be on a specified thread, e.g. a
+         * UI thread.
+         *
+         * @param executor the executor to run drains on
+         * @return a new builder that uses executor based draining
+         * @see DrainingOn
+         * @see java.util.concurrent.Executors
+         * @see javafx.application.Platform#runLater(Runnable)
+         */
+        public DebouncerBuilder<V, R> drainingOn(Executor executor) {
+            Objects.requireNonNull(executor);
+            return new DebouncerBuilder<>(new DrainingOn<>(accumulator, executor));
+        }
+
+        /**
+         * Set the regulator factory.
+         * <p>
+         * e.g. <pre>{@code
+         *  runnable -> DelayedRegulator(scheduler, delayMillis, runnable);
+         * }</pre>
+         * <p>
+         * Since many regulators need a final {@code Runnable}, a function that that takes a runnable
+         * and returns a regulator is required.
+         * The factory will only be invoked once.
+         *
+         * @param regulatorFactory factory method that accepts a runnable and returns a regulator
+         * @return the next phase of the builder which allows setting the drainer
+         * @see Regulator
+         * @see DebouncerBuilderRegulation#draining(Consumer)
+         */
+        public DebouncerBuilderRegulation<V, R> regulating(Function<Runnable, Regulator> regulatorFactory) {
+            Objects.requireNonNull(regulatorFactory);
+            return new DebouncerBuilderRegulation<>(this, regulatorFactory);
+        }
+    }
+
+    /**
+     * Final phase of debounce builder.
+     * Allows setting the draining function.
+     *
+     * @param <V> the value type to be accumulated
+     * @param <R> the result type to be consumed later
+     */
+    public static class DebouncerBuilderRegulation<V, R> {
+        private final DebouncerBuilder<V, R> accumulation;
+        private final Function<Runnable, Regulator> regulatorFactory;
+
+        private DebouncerBuilderRegulation(DebouncerBuilder<V, R> accumulation,
+                                           Function<Runnable, Regulator> regulatorFactory) {
+            this.accumulation = accumulation;
+            this.regulatorFactory = regulatorFactory;
+        }
+
+        /**
+         * Set the drainer for the debouncer.
+         * The drainer will be invoked with the current result value from the accumulator.
+         * <br/>
+         * <strong>Note:</strong> the accumulator may choose to reuse the value passed to consumer,
+         * so care must be taken when deciding what values should be used outside of the consumer.
+         *
+         * @param drainer the drainer to be invoked when the regulator runs
+         * @return the debouncer that has been built so far
+         * @see Accumulator#drain(Consumer)
+         * @see com.frynd.debouncer.drainer.Drainers
+         */
+        public Debouncer<V> draining(Consumer<? super R> drainer) {
+            Objects.requireNonNull(drainer);
+            Accumulator<V, R> accumulator = accumulation.accumulator;
+            Regulator regulator = regulatorFactory.apply(() -> accumulator.drain(drainer));
+            return new Debouncer<>(accumulator, regulator);
+        }
+    }
+
+}

--- a/src/main/java/com/frynd/debouncer/accumulator/decorator/AccumulatingOn.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/decorator/AccumulatingOn.java
@@ -1,0 +1,39 @@
+package com.frynd.debouncer.accumulator.decorator;
+
+import com.frynd.debouncer.accumulator.Accumulator;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/**
+ * Accumulator decorator for off-loading accumulation to a separate executor.
+ * <br/>
+ * Usage: <pre>{@code
+ *      Accumulator<String, List<String>> accumulator = ...;
+ *      Executor executor = ...; //e.g. Executors.newSingleThreadExecutor()
+ *      accumulator = new AccumulatingOn(accumulator, executor);
+ *
+ * }</pre>
+ * @param <V> The accumulating value type of the decorated accumulator
+ * @param <R> The result type of the decorated accumulator
+ * @see java.util.concurrent.Executors
+ */
+public class AccumulatingOn<V, R> extends AccumulatorDecorator<V, R> {
+    private final Executor executor;
+
+    /**
+     * Create an accumulator that executes accumulation actions on the executor.
+     * @param decorated the decorated accumulator
+     * @param executor the executor to run accumulations on
+     */
+    public AccumulatingOn(Accumulator<V, R> decorated, Executor executor) {
+        super(decorated);
+        Objects.requireNonNull(executor);
+        this.executor = executor;
+    }
+
+    @Override
+    public void accumulate(V item) {
+        executor.execute(() -> super.accumulate(item));
+    }
+}

--- a/src/main/java/com/frynd/debouncer/accumulator/decorator/DrainingOn.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/decorator/DrainingOn.java
@@ -1,0 +1,42 @@
+package com.frynd.debouncer.accumulator.decorator;
+
+import com.frynd.debouncer.accumulator.Accumulator;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+/**
+ * Accumulator decorator for off-loading draining to a separate executor.
+ * This can be useful, if, for example, the consumers update the UI and need
+ * to be on the UI thread.
+ * <br/>
+ * Usage: <pre>{@code
+ *      Accumulator<String, List<String>> accumulator = ...;
+ *      Executor executor = ...; //e.g. javafx.application.Platform::runLater
+ *      accumulator = new DrainingOn(accumulator, executor);
+ * }</pre>
+ * @param <V> The accumulating value type of the decorated accumulator
+ * @param <R> The result type of the decorated accumulator
+ * @see java.util.concurrent.Executors
+ * @see javafx.application.Platform#runLater(Runnable)
+ */
+public class DrainingOn<V, R> extends AccumulatorDecorator<V, R> {
+    private final Executor executor;
+
+    /**
+     * Create an accumulator that executes draining actions on the executor.
+     * @param decorated the decorated accumulator
+     * @param executor the executor to run drains on
+     */
+    public DrainingOn(Accumulator<V, R> decorated, Executor executor) {
+        super(decorated);
+        Objects.requireNonNull(executor);
+        this.executor = executor;
+    }
+
+    @Override
+    public void drain(Consumer<? super R> consumer) {
+        executor.execute(() -> super.drain(consumer));
+    }
+}

--- a/src/test/java/com/frynd/debouncer/DebouncerTest.java
+++ b/src/test/java/com/frynd/debouncer/DebouncerTest.java
@@ -1,0 +1,105 @@
+package com.frynd.debouncer;
+
+import com.frynd.debouncer.accumulator.impl.ListAccumulator;
+import com.frynd.debouncer.drainer.Drainers;
+import com.frynd.debouncer.regulator.impl.CountingRegulator;
+import com.frynd.debouncer.regulator.impl.ImmediateRegulator;
+import com.frynd.debouncer.test.CountingExecutor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class DebouncerTest {
+
+    @Test
+    @DisplayName("Debouncer builder requires non-null accumulator, regulator, and drainer.")
+    void accumulating() {
+        Debouncer<Integer> debouncer = Debouncer.accumulating(new ListAccumulator<Integer>())
+                .regulating(ImmediateRegulator::new).draining(Drainers.noopDrainer());
+        Assertions.assertNotNull(debouncer, "Debounce builder should return non-null.");
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> Debouncer.accumulating(null),
+                "Shouldn't be able to start a debouncer with a null accumulator.");
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> Debouncer.accumulating(new ListAccumulator<Integer>()).accumulatingOn(null),
+                "Shouldn't be able to build a debouncer with a null accumulation executor.");
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> Debouncer.accumulating(new ListAccumulator<Integer>()).drainingOn(null),
+                "Shouldn't be able to build a debouncer with a null drain executor.");
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> Debouncer.accumulating(new ListAccumulator<Integer>()).regulating(null),
+                "Shouldn't be able to build a debouncer with a null regulator.");
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> Debouncer.accumulating(new ListAccumulator<Integer>())
+                        .regulating(ImmediateRegulator::new)
+                        .draining(null),
+                "Shouldn't be able to build a debouncer with a null drainer.");
+    }
+
+    @Test
+    @DisplayName("Debouncer should accumulate events until the regulator runs.")
+    void accumulate() {
+        int count = 10;
+        List<Integer> numbers = new ArrayList<>(count);
+        Debouncer<Integer> debouncer = Debouncer.accumulating(new ListAccumulator<Integer>())
+                .regulating(runnable -> new CountingRegulator(count, runnable))
+                .draining(acc -> {
+                    numbers.clear();
+                    numbers.addAll(acc);
+                });
+
+        Assertions.assertTrue(numbers.isEmpty(), "Numbers should still be empty.");
+
+        List<Integer> expected = new ArrayList<>(count);
+        for (int i = 0; i < count - 1; ++i) {
+            debouncer.accumulate(i);
+            Assertions.assertTrue(numbers.isEmpty(), "Numbers should still be empty on iteration [" + i + "]. Was: " + numbers);
+            expected.add(i);
+        }
+
+        expected.add(count - 1);
+        debouncer.accumulate(count - 1);
+        Assertions.assertIterableEquals(expected, numbers, "Numbers should have been updated.");
+    }
+
+    @Test
+    void accumulateExecutors() {
+        CountingExecutor accumulationExecutor = new CountingExecutor();
+        CountingExecutor drainerExecutor = new CountingExecutor();
+
+        int count = 10;
+        List<Integer> numbers = new ArrayList<>(count);
+        Debouncer<Integer> debouncer = Debouncer.accumulating(new ListAccumulator<Integer>())
+                .accumulatingOn(accumulationExecutor)
+                .drainingOn(drainerExecutor)
+                .regulating(runnable -> new CountingRegulator(count, runnable))
+                .draining(acc -> {
+                    numbers.clear();
+                    numbers.addAll(acc);
+                });
+
+        Assertions.assertTrue(numbers.isEmpty(), "Numbers should still be empty.");
+
+        List<Integer> expected = new ArrayList<>(count);
+        for (int i = 0; i < count - 1; ++i) {
+            debouncer.accumulate(i);
+            Assertions.assertTrue(numbers.isEmpty(), "Numbers should still be empty on iteration [" + i + "]. Was: " + numbers);
+            expected.add(i);
+        }
+
+        expected.add(count - 1);
+        debouncer.accumulate(count - 1);
+        Assertions.assertIterableEquals(expected, numbers, "Numbers should have been updated.");
+
+        Assertions.assertEquals(count, accumulationExecutor.getCount(), "[" + count + "] events were accumulated.");
+        Assertions.assertEquals(1, drainerExecutor.getCount(), "Only one drain should have been performed.");
+    }
+}

--- a/src/test/java/com/frynd/debouncer/accumulator/decorator/AccumulatingOnTest.java
+++ b/src/test/java/com/frynd/debouncer/accumulator/decorator/AccumulatingOnTest.java
@@ -1,0 +1,40 @@
+package com.frynd.debouncer.accumulator.decorator;
+
+import com.frynd.debouncer.accumulator.Accumulator;
+import com.frynd.debouncer.accumulator.impl.LatestValueAccumulator;
+import com.frynd.debouncer.accumulator.impl.ListAccumulator;
+import com.frynd.debouncer.test.CountingExecutor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AccumulatingOnTest {
+
+    @Test
+    @DisplayName("AccumulatingOn requires a non-null accumulator and executor.")
+    void constructor() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new AccumulatingOn<>(new ListAccumulator<String>(), null),
+                "Cannot create accumulator that accumulates on null.");
+    }
+
+    @Test
+    @DisplayName("AccumulatingOn should accumulate through the executor.")
+    void accumulate() {
+        CountingExecutor countingExecutor = new CountingExecutor();
+
+        Accumulator<String, String> accumulator = new LatestValueAccumulator<>();
+        accumulator = new AccumulatingOn<>(accumulator, countingExecutor);
+        accumulator.accumulate("a");
+        accumulator.accumulate("b");
+        accumulator.accumulate("c");
+        accumulator.accumulate("d");
+
+        Assertions.assertEquals(4, countingExecutor.getCount(), "Supplied 4 values through the executor.");
+
+        accumulator.drain(str -> Assertions.assertEquals("d", str,
+                "Latest value should still be final value supplied."));
+
+        Assertions.assertEquals(4, countingExecutor.getCount(), "Only supplied 4 values through the executor.");
+    }
+}

--- a/src/test/java/com/frynd/debouncer/accumulator/decorator/DrainingOnTest.java
+++ b/src/test/java/com/frynd/debouncer/accumulator/decorator/DrainingOnTest.java
@@ -1,0 +1,39 @@
+package com.frynd.debouncer.accumulator.decorator;
+
+import com.frynd.debouncer.accumulator.Accumulator;
+import com.frynd.debouncer.accumulator.impl.LatestValueAccumulator;
+import com.frynd.debouncer.accumulator.impl.ListAccumulator;
+import com.frynd.debouncer.test.CountingExecutor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DrainingOnTest {
+
+    @Test
+    @DisplayName("DrainingOn requires a non-null accumulator and executor.")
+    void constructor() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new DrainingOn<>(new ListAccumulator<String>(), null),
+                "Cannot create accumulator that accumulates on null.");
+    }
+
+    @Test
+    @DisplayName("DrainingOn should drain through the provided executor.")
+    void accumulate() {
+        CountingExecutor countingExecutor = new CountingExecutor();
+        Accumulator<String, String> accumulator = new LatestValueAccumulator<>();
+        accumulator = new DrainingOn<>(accumulator, countingExecutor);
+        accumulator.accumulate("a");
+        accumulator.accumulate("b");
+        accumulator.accumulate("c");
+        accumulator.accumulate("d");
+
+        Assertions.assertEquals(0, countingExecutor.getCount(), "Nothing should have gone through the executor yet.");
+
+        accumulator.drain(str -> Assertions.assertEquals("d", str,
+                "Latest value should still be final value supplied."));
+
+        Assertions.assertEquals(1, countingExecutor.getCount(), "Drained through executor once.");
+    }
+}

--- a/src/test/java/com/frynd/debouncer/accumulator/impl/MapAccumulatorTest.java
+++ b/src/test/java/com/frynd/debouncer/accumulator/impl/MapAccumulatorTest.java
@@ -2,7 +2,7 @@ package com.frynd.debouncer.accumulator.impl;
 
 import com.frynd.debouncer.accumulator.Accumulator;
 import com.frynd.debouncer.drainer.Drainers;
-import com.frynd.debouncer.accumulator.Record;
+import com.frynd.debouncer.test.Record;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/frynd/debouncer/drainer/DrainersTest.java
+++ b/src/test/java/com/frynd/debouncer/drainer/DrainersTest.java
@@ -1,7 +1,9 @@
-package com.frynd.debouncer.accumulator;
+package com.frynd.debouncer.drainer;
 
+import com.frynd.debouncer.accumulator.Accumulator;
 import com.frynd.debouncer.accumulator.impl.ListAccumulator;
 import com.frynd.debouncer.drainer.Drainers;
+import com.frynd.debouncer.test.Record;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/frynd/debouncer/examples/HelloWorld.java
+++ b/src/test/java/com/frynd/debouncer/examples/HelloWorld.java
@@ -1,0 +1,29 @@
+package com.frynd.debouncer.examples;
+
+import com.frynd.debouncer.Debouncer;
+import com.frynd.debouncer.accumulator.impl.ListAccumulator;
+import com.frynd.debouncer.regulator.impl.DelayedRegulator;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class HelloWorld {
+
+    public static void main(String[] args) {
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
+        long delay = Duration.ofSeconds(1).toMillis();
+
+        Debouncer<Integer> debouncer = Debouncer.accumulating(new ListAccumulator<Integer>())
+                .regulating(runnable -> new DelayedRegulator(scheduler, delay, runnable))
+                .draining(numbers -> System.out.println("Accumulated: " + numbers));
+
+        AtomicInteger count = new AtomicInteger(0);
+
+        scheduler.scheduleAtFixedRate(() -> debouncer.accumulate(count.getAndIncrement()), delay / 9,
+                delay / 9, TimeUnit.MILLISECONDS);
+    }
+}
+

--- a/src/test/java/com/frynd/debouncer/test/CountingExecutor.java
+++ b/src/test/java/com/frynd/debouncer/test/CountingExecutor.java
@@ -1,0 +1,23 @@
+package com.frynd.debouncer.test;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Test executor class.
+ * Not a great executor, but indicates how many commands were run.
+ *
+ * @see #getCount()
+ */
+public class CountingExecutor implements Executor {
+    private int counter = 0;
+
+    @Override
+    public void execute(Runnable command) {
+        ++counter;
+        command.run();
+    }
+
+    public int getCount() {
+        return counter;
+    }
+}

--- a/src/test/java/com/frynd/debouncer/test/Record.java
+++ b/src/test/java/com/frynd/debouncer/test/Record.java
@@ -1,4 +1,4 @@
-package com.frynd.debouncer.accumulator;
+package com.frynd.debouncer.test;
 
 import java.util.Objects;
 


### PR DESCRIPTION
Adds the Debouncer class, along with a builder for it. Entry point is Debouncer.accumulating(Accumulator).

Adds two new Accumulator decorators:
- AccumulatingOn - decorate an accumulator to run accumulations on an executor.
- DrainingOn - decorate an accumulator to run drains on an executor

Debounce builder includes two methods to wrap the accumulator in the new decorators

Moved DrainersTest into same package as Drainers.
Moved a couple test classes into their own test package.

Updated README file.

Added HelloWorld example.