### PR TITLE
Adding BlockingQueueAccumulator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ The result type drives the generic type of the consumer passed as the drainer.
 |Accumulator | Description | Value Type | Result Type | Purpose|
 |----------- | ----------- | ---------- | ----------- | -------|
 |<a name="LatestValueAccumulator"/>`LatestValueAccumulator` | Only keeps the last value accumulated. | `T` | `T` | User is typing, but only need the final value entered.|
-|<a name="ListAccumulator"/>`ListAccumulator` | Keeps a list of value types accumulated | `T` | `List<T>` | Rapid events from an external source. All events need to be shown, but multiple updates would cause flickering.|
-|<a name="CollectionAccumulator"/>`CollectionAccumulator` | Keeps a collection of value types accumulated | `T` | `Collection<T>` | Similar to ListAccumulator, but can use an arbitrary backing collection.|
+|<a name="ListAccumulator"/>`ListAccumulator` | Keeps a list of value types accumulated. | `T` | `List<T>` | Rapid events from an external source. All events need to be shown, but multiple updates would cause flickering.|
+|<a name="BlockingQueueAccumulator"/>`BlockingQueueAccumulator` | Keeps a list of value types accumulated using a `BlockingQueue` as the backing storage. | `T` | `List<T>` | Concurrent version of `ListAccumulator`.|
+|<a name="CollectionAccumulator"/>`CollectionAccumulator` | Keeps a collection of value types accumulated. | `T` | `Collection<T>` | Similar to `ListAccumulator`, but can use an arbitrary backing collection.|
 |<a name="MapAccumulator"/>`MapAccumulator` | Keeps a map of value types to sub-accumulators. | `V` | `Map<K, Accumulator<V, R>>`| Rapid events coming in from an external source. Each event has a key that it can be grouped by. The resulting groupings can then be accumulated by one of the other accumulators. (See [Drainers.drainMap](#drainMap))|
 
 Accumulator decorators are also included, with the following implementation:
 
 |Decorator | Usage|
 |--------- | -----|
-|<a name="SynchronizedAccumulator"/>`SynchronizedAccumulator` | Used to wrap an accumulator's calls in `synchronized` blocks.|
+|<a name="SynchronizedAccumulator"/>`SynchronizedAccumulator` | Used to wrap an accumulator's calls in `synchronized` blocks. Wrapping `ListAccumulator` has similar performance to `BlockingQueueAccumulator`.|
 |<a name="AccumulatingOn"/>`AccumulatingOn` | Used to put an accumulator's accumulation calls on a separate executor.|
 |<a name="DrainingOn"/>`DrainingOn` | Used to put an accumulator's drain calls on a separate executor.|
 

--- a/src/main/java/com/frynd/debouncer/accumulator/impl/BlockingQueueAccumulator.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/impl/BlockingQueueAccumulator.java
@@ -1,0 +1,52 @@
+package com.frynd.debouncer.accumulator.impl;
+
+import com.frynd.debouncer.accumulator.Accumulator;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Consumer;
+
+/**
+ * Accumulator that stores accumulations in a BlockingQueue which drains to a
+ * list which is passed to the consumer.
+ * <br/>
+ * Usage: <pre>{@code
+ *     BlockingQueueAccumulator<String> accumulator = new BlockingQueueAccumulator<>();
+ *     accumulator.accumulate("a");
+ *     accumulator.accumulate("b");
+ *     accumulator.accumulate("c");
+ *     accumulator.drain(System.out::println); //prints "[a,b,c]";
+ * }</pre>
+ *
+ * @param <T> The type of item accumulated.
+ */
+public class BlockingQueueAccumulator<T> implements Accumulator<T, List<T>> {
+    private final LinkedBlockingQueue<T> queue = new LinkedBlockingQueue<>();
+
+    /**
+     * Accumulate the item into the current result.
+     *
+     * @param item the item to accumulate
+     */
+    @Override
+    public void accumulate(T item) {
+        queue.add(item);
+    }
+
+    /**
+     * Drain all currently accumulated values into a list, which is then
+     * passed to the {@code consumer}.
+     *
+     * @param consumer the consumer to pass the current result value to
+     */
+    @Override
+    @SuppressWarnings("squid:S899")
+    public void drain(Consumer<? super List<T>> consumer) {
+        Objects.requireNonNull(consumer);
+        List<T> list = new LinkedList<>();
+        queue.drainTo(list);
+        consumer.accept(list);
+    }
+}

--- a/src/main/java/com/frynd/debouncer/accumulator/impl/CollectionAccumulator.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/impl/CollectionAccumulator.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 
 /**
  * Accumulator that accumulates all items into a provided collection.
+ * <br/>
  * Usage: <pre>{@code
  *     CollectionAccumulator<String, Set<String>> accumulator = new CollectionAccumulator<>(new LinkedHashSet<>());
  *     accumulator.accumulate("a");
@@ -42,7 +43,7 @@ public class CollectionAccumulator<V, C extends Collection<V>> implements Accumu
     }
 
     /**
-     * Add the item to the current result list
+     * Add the item to the current result collection
      *
      * @param item the item to accumulate
      */

--- a/src/main/java/com/frynd/debouncer/accumulator/impl/LatestValueAccumulator.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/impl/LatestValueAccumulator.java
@@ -7,6 +7,7 @@ import java.util.function.Consumer;
 
 /**
  * Accumulator that accumulates only the latest item.
+ * <br/>
  * Usage: <pre>{@code
  *     LatestValueAccumulator<String> accumulator = new LatestValueAccumulator<>();
  *     accumulator.accumulate("a");

--- a/src/main/java/com/frynd/debouncer/accumulator/impl/ListAccumulator.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/impl/ListAccumulator.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 
 /**
  * Accumulator that accumulates all items into a list until drained.
+ * <br/>
  * Usage: <pre>{@code
  *     ListAccumulator<String> accumulator = new ListAccumulator<>();
  *     accumulator.accumulate("a");

--- a/src/main/java/com/frynd/debouncer/accumulator/impl/MapAccumulator.java
+++ b/src/main/java/com/frynd/debouncer/accumulator/impl/MapAccumulator.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 
 /**
  * Accumulates values into sub-accumulators grouped by key.
+ * <br/>
  * Usage: <pre>{@code
  *      MapAccumulator<Record, String, Record> latestByUserId = new MapAccumulator<>(
  *        Record::getUserId,

--- a/src/test/java/com/frynd/debouncer/accumulator/impl/BlockingQueueAccumulatorTest.java
+++ b/src/test/java/com/frynd/debouncer/accumulator/impl/BlockingQueueAccumulatorTest.java
@@ -1,0 +1,105 @@
+package com.frynd.debouncer.accumulator.impl;
+
+import com.frynd.debouncer.accumulator.Accumulator;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.*;
+
+class BlockingQueueAccumulatorTest {
+
+    private static final int CONCURRENCY = 100;
+    private static final Comparator<Integer> COMPARATOR = Comparator.nullsFirst(Comparator.naturalOrder());
+
+    private Accumulator<Integer, List<Integer>> fixture;
+    private ExecutorService service;
+
+    @BeforeEach
+    void setUp() {
+        fixture = new BlockingQueueAccumulator<>();
+        service = Executors.newFixedThreadPool(CONCURRENCY);
+    }
+
+    @AfterEach
+    void tearDown() {
+        service.shutdown();
+    }
+
+
+    @RepeatedTest(10)//Due to non-deterministic nature, even non-concurrent version can frequently pass
+    @DisplayName("Concurrent accumulator should handle multiple threads attempting access simultaneously.")
+    void accumulate() throws Exception {
+        CyclicBarrier startBarrier = new CyclicBarrier(CONCURRENCY + 1); //+1 for this thread
+
+        List<Integer> expected = new ArrayList<>(CONCURRENCY);
+        List<Future<?>> futures = new ArrayList<>(CONCURRENCY);
+
+        for (int i = 0; i < CONCURRENCY; ++i) {
+            final int submission = i;
+            futures.add(service.submit(() -> {
+                startBarrier.await();
+                fixture.accumulate(submission);
+                return null;
+            }));
+            expected.add(submission);
+        }
+
+        startBarrier.await();
+        //Not strictly needed to sort the expected list, but wanted to make sure the same operation on expected as values
+        expected.sort(COMPARATOR);
+
+        for (Future<?> future : futures) {
+            future.get();
+        }
+
+        fixture.drain(values -> {
+            values.sort(COMPARATOR);
+            Assertions.assertIterableEquals(expected, values, "Should contain all values.");
+        });
+    }
+
+    @SuppressWarnings("squid:S2925")//Sleeping in submits to space out accumulates while main thread reads
+    @RepeatedTest(10)//Due to non-deterministic nature, even non-concurrent version can frequently pass
+    @DisplayName("Concurrent accumulator should be able to drain mid-accumulate storm.")
+    void drain() throws Exception {
+        CyclicBarrier startBarrier = new CyclicBarrier(CONCURRENCY + 1); //+1 for this thread
+        Comparator<Integer> comparator = Comparator.nullsFirst(Comparator.naturalOrder());
+
+        List<Integer> expected = new ArrayList<>(CONCURRENCY);
+        List<Future<?>> futures = new ArrayList<>(CONCURRENCY);
+
+        for (int i = 0; i < CONCURRENCY; ++i) {
+            final int submission = i;
+            futures.add(
+                    service.submit(() -> {
+                        startBarrier.await();
+                        Thread.sleep((submission / 10) * 2);
+                        fixture.accumulate(submission);
+                        return null;
+                    })
+            );
+            expected.add(submission);
+        }
+
+        startBarrier.await();
+
+        CopyOnWriteArrayList<Integer> actualList = new CopyOnWriteArrayList<>();
+        Thread.sleep(10);
+        fixture.drain(actualList::addAll);
+        Thread.sleep(10);
+        fixture.drain(actualList::addAll);
+
+        //Not strictly needed to sort the expected list, but wanted to make sure the same operation on expected as values
+        expected.sort(comparator);
+
+        for (Future<?> future : futures) {
+            future.get();
+        }
+
+        fixture.drain(actualList::addAll);
+        actualList.sort(COMPARATOR);
+        Assertions.assertIterableEquals(expected, actualList, "Draining multiple times should result in same.");
+    }
+}


### PR DESCRIPTION
BlockingQueueAccumulator uses a BlockingQueue as the backing storage for accumulation, which it drains to a list before passing it to the consumer.

Updated javadoc formatting in accumulators.

Updated README.