### PR TITLE
Adding SimpleEditorDemo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A debouncer is made up of three parts.
 Debouncer is built through a builder where each part is supplied.
 
 ```java
-package com.frynd.debouncer.examples;
+package com.frynd.debouncer.examples.hello;
 
 import com.frynd.debouncer.Debouncer;
 import com.frynd.debouncer.accumulator.impl.ListAccumulator;
@@ -23,7 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class HelloWorld {
+public class HelloWorldDemo {
 
     public static void main(String[] args) {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
@@ -42,6 +42,8 @@ public class HelloWorld {
 }
 ```
 Note: The regulator is supplied through a factory, rather than directly, to allow storage of the runnable to be final.
+
+More examples are included the test/java/com/frynd/debouncer/examples folder.
 
 ### <a name="accumulators"/> Accumulators
 Accumulators accumulate value types into a result type. 

--- a/src/test/java/com/frynd/debouncer/examples/editor/SimpleEditorDemo.java
+++ b/src/test/java/com/frynd/debouncer/examples/editor/SimpleEditorDemo.java
@@ -1,0 +1,28 @@
+package com.frynd.debouncer.examples.editor;
+
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+
+/**
+ * Extremely simple HTML editor to demonstrate showing loading state while user is typing.
+ *
+ * @see SimpleEditorDemoController
+ */
+public class SimpleEditorDemo extends Application {
+    @Override
+    public void start(Stage primaryStage) throws IOException {
+        Parent root = FXMLLoader.load(SimpleEditorDemo.class.getResource("/editor/editor.fxml"));
+        primaryStage.setTitle("Simple Editor");
+        primaryStage.setScene(new Scene(root));
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/src/test/java/com/frynd/debouncer/examples/editor/SimpleEditorDemoController.java
+++ b/src/test/java/com/frynd/debouncer/examples/editor/SimpleEditorDemoController.java
@@ -1,0 +1,114 @@
+package com.frynd.debouncer.examples.editor;
+
+import com.frynd.debouncer.Debouncer;
+import com.frynd.debouncer.accumulator.impl.LatestValueAccumulator;
+import com.frynd.debouncer.regulator.impl.QuiescentRegulator;
+import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.StringExpression;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.fxml.FXML;
+import javafx.scene.Node;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.web.WebView;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+/**
+ * Simple editor fxml controller
+ * <br/>
+ * Loads a template file: "editor/template.html" which has a {@code %s} format string.
+ * Replaces the %s using with the text input by the user.
+ * Displays the effective text immediately in the "Effective Text" tab.
+ * As the user types into the input box, a "rendering" state will be displayed.
+ * The "rendering" state persists for as long as the user is changing more than one key every {@code TYPING_MILLIS} milliseconds.
+ * Then the text the user has typed is rendered into the webview {@code renderer}.
+ * <br/>
+ * This is to simulate a situation where rendering might instead be a longer process, such as an external service
+ * request to query data, so we want to wait for the user to stop typing before making the service call.
+ */
+public class SimpleEditorDemoController {
+    // Create a scheduler pool. This would be better done with a guava ThreadFactoryBuilder and/or stored separately
+    // as a static shared pool.
+    private static final ScheduledExecutorService SCHEDULER_POOL = Executors.newScheduledThreadPool(1,
+            runnable -> {
+                Thread thread = new Thread(runnable, "debounce-thread");
+                thread.setDaemon(true);
+                thread.setPriority(Thread.MIN_PRIORITY);
+                return thread;
+            });
+
+    // The approximate milliseconds when it is determined the user has probably finished typing
+    private static final int TYPING_MILLIS = 1000;
+
+    @FXML
+    private TextInputControl textEntry; // the text field the user enters text into
+
+    @FXML
+    private TextInputControl effectiveText; // the node to display the template with the user entered text inserted
+
+    @FXML
+    private WebView renderer; // the html renderer
+
+    @FXML
+    private Node loadingNode; // the node to display while loading
+    private BooleanProperty rendering = new SimpleBooleanProperty(false); // controls the rendering state
+
+    public void initialize() throws Exception {
+        // Load the template to a string.
+        String template = buildTemplateString();
+
+        // Build the debouncer
+        Debouncer<String> debouncer = buildTextRenderDebouncer();
+
+        // Sets up the filled out template binding
+        StringExpression formatted = Bindings.format(template, textEntry.textProperty());
+        // effectiveText updates instantly while user is typing
+        effectiveText.textProperty().bind(formatted);
+
+        // add a listener so that when the filled out template changes
+        // switches into rendering mode and pushes the latest up to the debouncer.
+        formatted.addListener((observable, oldValue, newValue) -> {
+            rendering.set(true);
+            debouncer.accumulate(newValue);
+        });
+
+        // set up the control of the display through the rendering state
+        loadingNode.visibleProperty().bind(rendering);
+        loadingNode.managedProperty().bind(rendering);
+        renderer.visibleProperty().bind(rendering.not());
+
+        // set the renderer to show any content already entered before initialize is called.
+        renderer.getEngine().loadContent(formatted.get());
+    }
+
+    private Debouncer<String> buildTextRenderDebouncer() {
+
+        return Debouncer
+                .accumulating(new LatestValueAccumulator<String>())// only care about the final state of what the user typed
+                .drainingOn(Platform::runLater) // Updates to UI should be done on the FX Application thread
+                .regulating(runnable -> new QuiescentRegulator(SCHEDULER_POOL, TYPING_MILLIS, runnable)) // waiting for the user to stop typing
+                .draining(content -> {
+                    renderer.getEngine().loadContent(content); // render the user text in the renderer
+                    rendering.set(false); // set the rendering state to finished.
+                });
+    }
+
+    private String buildTemplateString() throws URISyntaxException, IOException {
+        // Not the most efficient way to load the text, but works for now...
+        URL templateURL = SimpleEditorDemoController.class.getResource("/editor/template.html");
+        Path path = Paths.get(templateURL.toURI());
+        List<String> lines = Files.readAllLines(path);
+        return lines.stream().collect(Collectors.joining("\n"));
+    }
+}

--- a/src/test/java/com/frynd/debouncer/examples/hello/HelloWorldDemo.java
+++ b/src/test/java/com/frynd/debouncer/examples/hello/HelloWorldDemo.java
@@ -1,4 +1,4 @@
-package com.frynd.debouncer.examples;
+package com.frynd.debouncer.examples.hello;
 
 import com.frynd.debouncer.Debouncer;
 import com.frynd.debouncer.accumulator.impl.ListAccumulator;
@@ -10,7 +10,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class HelloWorld {
+public class HelloWorldDemo {
 
     public static void main(String[] args) {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);

--- a/src/test/resources/editor/editor.css
+++ b/src/test/resources/editor/editor.css
@@ -1,0 +1,33 @@
+.root {
+  primary: #317873;
+  accent: derive(primary, 60%);
+
+  -fx-focus-color: primary;
+  -fx-accent: accent;
+
+  -fx-pref-width: 50em;
+  -fx-pref-height: 37.5em;
+}
+
+.header {
+  -fx-background-color: primary;
+  -fx-text-background-color: ladder(primary , white 49%, black 50%);
+  -fx-padding: 1em;
+}
+
+.header-title {
+  -fx-font-size: 2em;
+}
+
+.header-sub-title {
+  -fx-font-style: italic;
+}
+
+.smokey {
+  -fx-background-color: accent;
+  -fx-opacity: 0.5;
+}
+
+.smokey > *{
+  -fx-opacity: 1.0;
+}

--- a/src/test/resources/editor/editor.fxml
+++ b/src/test/resources/editor/editor.fxml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.web.WebView?>
+<?import javafx.scene.layout.AnchorPane?>
+<BorderPane styleClass="root"
+            stylesheets="@editor.css" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="com.frynd.debouncer.examples.editor.SimpleEditorDemoController">
+    <top>
+        <VBox styleClass="header">
+            <Label styleClass="header-title" text="Simple Html Editor"/>
+            <Label styleClass="header-sub-title" text="Type to set the body of the html document."/>
+        </VBox>
+    </top>
+    <center>
+        <SplitPane dividerPositions="0.38">
+            <TextArea fx:id="textEntry"/>
+            <TabPane side="BOTTOM" tabClosingPolicy="UNAVAILABLE">
+                <Tab text="Rendered">
+                    <StackPane>
+                        <WebView fx:id="renderer" prefHeight="-1.0" prefWidth="-1.0"/>
+                        <StackPane fx:id="loadingNode" mouseTransparent="true">
+                            <AnchorPane styleClass="smokey"/>
+                            <ProgressIndicator maxHeight="-Infinity" maxWidth="-Infinity"
+                                               prefHeight="32.0" prefWidth="32.0"
+                                               StackPane.alignment="CENTER"/>
+                        </StackPane>
+                    </StackPane>
+                </Tab>
+                <Tab text="Effective Text">
+                    <TextArea fx:id="effectiveText" editable="false"/>
+                </Tab>
+            </TabPane>
+        </SplitPane>
+    </center>
+</BorderPane>

--- a/src/test/resources/editor/template.html
+++ b/src/test/resources/editor/template.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+%s
+</body>
+</html>


### PR DESCRIPTION
This adds a simple html editor demonstration example. It shows a loading/rendering page while the user types then does the actual rendering when the user stops typing.

Moved HelloWorldDemo into a separate examples package.

Updated README.md file to point to examples package.