### PR TITLE
Removed DebouncerBuilder phasing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ public class HelloWorldDemo {
 
         Debouncer<Integer> debouncer = Debouncer.accumulating(new ListAccumulator<Integer>())
                 .regulating(runnable -> new DelayedRegulator(scheduler, delay, runnable))
-                .draining(numbers -> System.out.println("Accumulated: " + numbers));
+                .draining(numbers -> System.out.println("Accumulated: " + numbers))
+                .build();
 
         AtomicInteger count = new AtomicInteger(0);
 

--- a/src/test/java/com/frynd/debouncer/DebouncerTest.java
+++ b/src/test/java/com/frynd/debouncer/DebouncerTest.java
@@ -18,7 +18,7 @@ class DebouncerTest {
     @DisplayName("Debouncer builder requires non-null accumulator, regulator, and drainer.")
     void accumulating() {
         Debouncer<Integer> debouncer = Debouncer.accumulating(new ListAccumulator<Integer>())
-                .regulating(ImmediateRegulator::new).draining(Drainers.noopDrainer());
+                .regulating(ImmediateRegulator::new).draining(Drainers.noopDrainer()).build();
         Assertions.assertNotNull(debouncer, "Debounce builder should return non-null.");
 
         Assertions.assertThrows(NullPointerException.class,
@@ -54,7 +54,8 @@ class DebouncerTest {
                 .draining(acc -> {
                     numbers.clear();
                     numbers.addAll(acc);
-                });
+                })
+                .build();
 
         Assertions.assertTrue(numbers.isEmpty(), "Numbers should still be empty.");
 
@@ -84,7 +85,8 @@ class DebouncerTest {
                 .draining(acc -> {
                     numbers.clear();
                     numbers.addAll(acc);
-                });
+                })
+                .build();
 
         Assertions.assertTrue(numbers.isEmpty(), "Numbers should still be empty.");
 

--- a/src/test/java/com/frynd/debouncer/examples/editor/SimpleEditorDemoController.java
+++ b/src/test/java/com/frynd/debouncer/examples/editor/SimpleEditorDemoController.java
@@ -102,7 +102,8 @@ public class SimpleEditorDemoController {
                 .draining(content -> {
                     renderer.getEngine().loadContent(content); // render the user text in the renderer
                     rendering.set(false); // set the rendering state to finished.
-                });
+                })
+                .build();
     }
 
     private String buildTemplateString() throws URISyntaxException, IOException {

--- a/src/test/java/com/frynd/debouncer/examples/hello/HelloWorldDemo.java
+++ b/src/test/java/com/frynd/debouncer/examples/hello/HelloWorldDemo.java
@@ -18,7 +18,8 @@ public class HelloWorldDemo {
 
         Debouncer<Integer> debouncer = Debouncer.accumulating(new ListAccumulator<Integer>())
                 .regulating(runnable -> new DelayedRegulator(scheduler, delay, runnable))
-                .draining(numbers -> System.out.println("Accumulated: " + numbers));
+                .draining(numbers -> System.out.println("Accumulated: " + numbers))
+                .build();
 
         AtomicInteger count = new AtomicInteger(0);
 

--- a/src/test/java/com/frynd/debouncer/examples/monitor/MonitorDemoController.java
+++ b/src/test/java/com/frynd/debouncer/examples/monitor/MonitorDemoController.java
@@ -134,7 +134,8 @@ public class MonitorDemoController {
                     if (update != null) {
                         putData(update.getName(), update.getValue());
                     }
-                }));
+                }))
+                .build();
 
         //Debouncer for checking the name is unique.
         //Technically, this isn't needed as the check is fast enough, but was a nice example
@@ -150,7 +151,8 @@ public class MonitorDemoController {
                 .draining(text -> {
                     checkNameInUse();
                     checkingName.set(false);
-                });
+                })
+                .build();
 
         //Schedule the printing of number of events received per second
         scheduler.scheduleAtFixedRate(() -> {


### PR DESCRIPTION
Changed DebouncerBuilder in Debouncer away from phased builder pattern
to a more direct immutable builder pattern. This allows reordering of
commands, but now requires a .build() at the end of each pre-exiting
builder call.